### PR TITLE
ignore the children

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -18,9 +18,14 @@ from xattree import (
 
 @xattree
 class Foo:
+    @attrs.define
+    class Bar:
+        pass
+
     i: int = field()
     d: int = dim()
     n: int = attrs.field()
+    c: Bar = attrs.field()
 
 
 class Bar:
@@ -37,6 +42,7 @@ def test_is_xat():
     assert is_xat(fields_["i"])
     assert is_xat(fields_["d"])
     assert not is_xat(fields_["n"])
+    assert not is_xat(fields_["c"])
 
 
 def test_fields():

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -47,7 +47,7 @@ def test_is_xat():
 
 def test_fields():
     fields_ = fields(Foo)
-    assert len(fields_) == 3
+    assert len(fields_) == 4
     assert fields_[0].name == "i"
     assert fields_[1].name == "d"
     assert fields_[2].name == "n"
@@ -56,15 +56,16 @@ def test_fields():
 
 def test_fields_extra():
     fields_ = fields(Foo, extra=True)
-    assert len(fields_) == 8
+    assert len(fields_) == 9
     assert fields_[0].name == "i"
     assert fields_[1].name == "d"
     assert fields_[2].name == "n"
-    assert fields_[3].name == "name"
-    assert fields_[4].name == "dims"
-    assert fields_[5].name == "parent"
-    assert fields_[6].name == "children"
-    assert fields_[7].name == "strict"
+    assert fields_[3].name == "c"
+    assert fields_[4].name == "name"
+    assert fields_[5].name == "dims"
+    assert fields_[6].name == "parent"
+    assert fields_[7].name == "children"
+    assert fields_[8].name == "strict"
     assert list(fields_dict(Foo, extra=True).values()) == fields_
 
 

--- a/xattree/__init__.py
+++ b/xattree/__init__.py
@@ -510,19 +510,19 @@ def _get_xatspec(cls: type) -> _XatSpec:
                             is_optional = True
                             origin = None
                             type_ = args[0]
-                    elif not origin and attrs_has(type_):
+                    elif not origin and has_xats(type_):
                         is_child = True
                         child_kind = "only"
                     elif iterable or mapping:
                         match len(args):
                             case 1:
                                 type_ = args[0]
-                                if attrs_has(type_):
+                                if has_xats(type_):
                                     is_child = True
                                     child_kind = "list"
                             case 2:
                                 type_ = args[1]
-                                if args[0] is str and attrs_has(type_):
+                                if args[0] is str and has_xats(type_):
                                     is_child = True
                                     child_kind = "dict"
                     if is_child:
@@ -1264,7 +1264,7 @@ def xattree(
                         pass
 
                 if not (
-                    attrs_has(type_)
+                    has_xats(type_)
                     or (mapping and attrs_has(args[-1]))
                     or (iterable and attrs_has(args[0]))
                 ):


### PR DESCRIPTION
We weren't properly ignoring child fields that don't explicitly use `xattree.field()`, even though the docs say we do.

Also, only make child `xattree.field`s nodes in the datatree if they are decorated with `xattree`. If they're plain old attrs classes, just make them data tree attrs.