### PR TITLE
fix child collections

### DIFF
--- a/docs/md/rules.md
+++ b/docs/md/rules.md
@@ -54,13 +54,17 @@ Besides applying the decorators as described above, develop your `attrs`-based o
 
 At import time, `xattree` walks your domain to discover its structure. Where it discovers a `field()` whose type is either another `xattree` node or an `Optional`, `Mapping` or `Iterable` of such, it inspects it recursively.
 
-When a field is another `xattree`-decorated class, an `Optional` of such, it simply becomes a child node in the data tree. When it's a `Mapping` or `Iterable` of some `xattree`-decorated class, `xattree` will "flatten" these before attaching them to the data tree &mdash; i.e., attach each element by name as a child instead of attaching the collection itself as a child.
+### Children
+
+When a field is another `xattree`-decorated class, or an `Optional`, `Mapping` or `Iterable` of such, we refer to it as a *child*. In the former two cases we have an *only child*, in the latter two we have *child collections*. `xattree` will "flatten" child collections &mdash; each element of the child collection is attached as a child datatree node instead of attaching the collection itself.
 
 Use a `Mapping` or `Iterable` if you don't want to name your children up front (i.e. when you define your object model) but at their moment of birth, which is perhaps understandable. Using an `Iterable` is effectively to declare that you don't want to have to name them, which, while deplorable among our kind, is standard feline conduct, therefore `xattree` grudgingly accepts but insists on naming anonymous children behind your back, appending an auto-incrementing integer to the name of their field.
 
 **Note**: While `xattree` will raise an error at runtime if a user-specified or auto-generated name collides with another fields, it's best to name fields such that collisions are impossible.
 
 **Note**: You may not reassign a child to a different parent if it already has one.
+
+**Note**: Children may be associated with parents via the `parent` parameter to the `__init__` method only if `xattree` can unambiguously identify which of the parent's fields the child corresponds to. This is not possible if the parent has multiple fields of the same child type (or `Optional`, `Iterable` or `Mapping` of such). 
 
 ## Bring your own conventions
 

--- a/test/test_child.py
+++ b/test/test_child.py
@@ -84,8 +84,6 @@ def test_child_list_access():
     assert parent.child_list[1] is children[1]
     assert parent.child_list[0] == children[0]
     assert parent.child_list[1] == children[1]
-    assert parent.data["child_list0"] is children[0].data
-    assert parent.data["child_list1"] is children[1].data
 
 
 def test_child_list_append():
@@ -161,8 +159,6 @@ def test_child_dict_access():
     assert parent.child_dict["child1"] is children[1]
     assert parent.child_dict["child0"] == children[0]
     assert parent.child_dict["child1"] == children[1]
-    assert parent.data["child0"] is children[0].data
-    assert parent.data["child1"] is children[1].data
 
 
 def test_child_dict_setitem():
@@ -331,5 +327,5 @@ def test_nested_child_dicts():
     assert grandparent.child_dict["0"] is parent
     assert grandparent.child_dict["0"].child_dict["0"] is children["0"]
     assert grandparent.data["0"] is parent.data
-    assert grandparent.data["0"]["0"] is children["0"].data
-    assert children["0"].data._host == children["0"]  # impl detail
+    assert grandparent.data["0"]["0"] is parent.data["0"]
+    assert children["0"].data._host == children["0"]

--- a/xattree/__init__.py
+++ b/xattree/__init__.py
@@ -584,6 +584,7 @@ def get_xatspec(cls: type) -> Mapping:
 def _bind_tree(
     self: Any,
     parent: Any = None,
+    parent_field: str = None,
     children: Optional[Mapping[str, Any]] = None,
     where: str = _WHERE_DEFAULT,
 ):
@@ -598,37 +599,62 @@ def _bind_tree(
 
     # bind parent
     if parent:
+        parent_cls = type(parent)
+        parent_spec = get_xatspec(parent_cls)
+
+        def _find_field(cls: type) -> Optional[str]:
+            matches = set()
+            for name, field in parent_spec.items():
+                if isinstance(field, _Child) and issubclass(cls, field.type):
+                    matches.add(name)
+            match len(matches):
+                case 0:
+                    raise TypeError(
+                        f"Class '{parent_cls.__name__}' has no fields of type {cls.__name__}"
+                    )
+                case 1:
+                    return matches.pop()
+                case _:
+                    raise TypeError(
+                        f"Class '{parent_cls.__name__}' has multiple fields of type "
+                        f"{cls.__name__}' ({', '.join(matches)}), can't bind."
+                    )
+
+        def _update_or_assign(field: _Child, name: str) -> tuple[str, bool, dict]:
+            match field.kind:
+                case "only":
+                    if name in parent.data:
+                        return name, True, {name: tree}
+                    else:
+                        return name, False, {name: tree, **parent_children}
+                case "list":
+                    same_type = {n: c for n, c in parent_children.items() if type(c._host) is cls}
+                    name = f"{name}{len(same_type)}"
+                    return name, name in parent.data, parent_children | {name: tree}
+                case "dict":
+                    return name, name in parent.data, parent_children | {name: tree}
+
+        if not parent_field:
+            parent_field = _find_field(cls)
+        if (field := parent_spec.get(parent_field, None)) is None:
+            raise TypeError(f"Class '{parent_cls.__name__}' has no field '{parent_field}'")
+        if not isinstance(field, _Child):
+            raise TypeError(f"Class '{parent_cls.__name__}' field '{parent_field}' is not a child")
+
         parent_tree = getattr(parent, where)
-        multi = cls.__xattree__.get(_MULTI, None)
-        anon = name == cls.__name__.lower()
-        match multi:
-            case "list":
-                items = {n: c for n, c in parent_tree.children.items()}
-                same_type = {n: c for n, c in items.items() if type(c._host) is cls}
-                name = f"{name}{len(same_type)}"
-                if anon:
-                    new = items | {name: tree}
-                else:
-                    new = {name: tree}
-                if name in parent.data:
-                    parent_tree.update(new)
-                else:
-                    parent_tree = parent_tree.assign(new)
-            case "dict" | True:
-                items = {n: c for n, c in parent_tree.children.items()}
-                if anon:
-                    new = items | {name: tree}
-                else:
-                    new = {name: tree}
-                if name in parent.data:
-                    parent_tree.update(new)
-                else:
-                    parent_tree = parent_tree.assign(new)
-            case False | None:
-                if name in parent.data:
-                    parent_tree.update({name: tree})
-                else:
-                    parent_tree = parent_tree.assign({name: tree, **parent_tree.children})
+        parent_children = {n: c for n, c in parent_tree.children.items()}
+        name, update, chldrn = _update_or_assign(field, name)
+        if update:
+            parent_tree.update(chldrn)
+        else:
+            parent_tree = parent_tree.assign(chldrn)
+            if not parent_tree.is_root:
+                current = {parent_tree.name: parent_tree}
+                for ancestor in parent_tree.iter_lineage():
+                    ancestor.update(current)
+                    if not ancestor.is_root:
+                        current = {ancestor.name: ancestor}
+
         parent_tree._host = parent
         setattr(parent, where, parent_tree)
         tree = parent_tree[name]
@@ -1313,12 +1339,15 @@ def xattree(
                     elif default is None and iterable:
                         raise ValueError("Child collection's default may not be None.")
                     metadata = field.metadata.copy() or {}
+                    multi = ("dict" if mapping else "list" if iterable else "only",)
                     metadata[_PKG_NAME] = {
                         _KIND: "child",
                         _TYPE: type_,
                         _OPTIONAL: optional,
-                        _MULTI: "dict" if mapping else "list" if iterable else "only",
+                        _MULTI: multi,
                     }
+                    # if has(cls_ := args[-1] if mapping else args[0] if iterable else type_):
+                    #     cls_.__xattree__[_MULTI] = multi
                     return Attribute(  # type: ignore
                         name=field.name,
                         default=default,

--- a/xattree/__init__.py
+++ b/xattree/__init__.py
@@ -652,7 +652,7 @@ def _bind_tree(
             parent_tree.update(new_children)
         else:
             is_root = parent_tree.is_root
-            lineage = parent_tree.iter_lineage()[1:]
+            lineage = parent_tree.parents
             parent_tree = parent_tree.assign(new_children)
             if not is_root:
                 other = {parent_tree.name: parent_tree}

--- a/xattree/__init__.py
+++ b/xattree/__init__.py
@@ -660,6 +660,7 @@ def _bind_tree(
                     ancestor.update(other)
                     if not ancestor.is_root:
                         other = {ancestor.name: ancestor}
+                parent_tree = lineage[0][parent_tree.name]
 
         parent_tree._host = parent
         setattr(parent, where, parent_tree)

--- a/xattree/__init__.py
+++ b/xattree/__init__.py
@@ -584,7 +584,7 @@ def get_xatspec(cls: type) -> Mapping:
 def _bind_tree(
     self: Any,
     parent: Any = None,
-    parent_field: str = None,
+    parent_field: str | None = None,
     children: Optional[Mapping[str, Any]] = None,
     where: str = _WHERE_DEFAULT,
 ):
@@ -605,7 +605,11 @@ def _bind_tree(
         def _find_field(cls: type) -> Optional[str]:
             matches = set()
             for name, field in parent_spec.items():
-                if isinstance(field, _Child) and issubclass(cls, field.type):
+                if (
+                    isinstance(field, _Child)
+                    and isclass(field.type)
+                    and issubclass(cls, field.type)
+                ):
                     matches.add(name)
             match len(matches):
                 case 0:

--- a/xattree/__init__.py
+++ b/xattree/__init__.py
@@ -647,17 +647,19 @@ def _bind_tree(
 
         parent_tree = getattr(parent, where)
         parent_children = {n: c for n, c in parent_tree.children.items()}
-        name, update, chldrn = _update_or_assign(field, name)
+        name, update, new_children = _update_or_assign(field, name)
         if update:
-            parent_tree.update(chldrn)
+            parent_tree.update(new_children)
         else:
-            parent_tree = parent_tree.assign(chldrn)
-            if not parent_tree.is_root:
-                current = {parent_tree.name: parent_tree}
-                for ancestor in parent_tree.iter_lineage():
-                    ancestor.update(current)
+            is_root = parent_tree.is_root
+            lineage = parent_tree.iter_lineage()[1:]
+            parent_tree = parent_tree.assign(new_children)
+            if not is_root:
+                other = {parent_tree.name: parent_tree}
+                for ancestor in lineage:
+                    ancestor.update(other)
                     if not ancestor.is_root:
-                        current = {ancestor.name: ancestor}
+                        other = {ancestor.name: ancestor}
 
         parent_tree._host = parent
         setattr(parent, where, parent_tree)
@@ -671,7 +673,6 @@ def _bind_tree(
         setattr(child, where, tree[n])
         _bind_tree(
             child,
-            parent=self,
             children={n: c._host for n, c in child_tree.children.items()},
             where=where,
         )


### PR DESCRIPTION
make sure we can bind unambiguously to parent. and bind recursively to the root of the tree by `update`-ing each ancestor. fixes #20 