### PR TITLE
dim groups

### DIFF
--- a/test/test_dim.py
+++ b/test/test_dim.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.typing import NDArray
 
-from xattree import array, dim, xattree
+from xattree import _get_xatspec, array, dim, xattree
 
 
 def test_dim_coord():
@@ -90,3 +90,31 @@ def test_derived_dim():
     nodes = n * n
     assert foo.nodes == nodes
     assert foo.data.dims["nodes"] == nodes
+
+
+def test_dim_group():
+    """Test that the group parameter works correctly."""
+
+    @xattree
+    class TestClass:
+        x: int = dim(group="spatial", default=3)
+        y: int = dim(group="temporal", default=4)
+        z: int = dim(group=None, default=5)  # Explicitly None
+        w: int = dim(default=6)  # No group parameter
+
+    # Test that the class can be instantiated
+    instance = TestClass()
+
+    # Test that the values are correct
+    assert instance.x == 3
+    assert instance.y == 4
+    assert instance.z == 5
+    assert instance.w == 6
+
+    # Test that the specifications have the correct group attributes
+    spec = _get_xatspec(TestClass)
+
+    assert spec.dims["x"].group == "spatial"
+    assert spec.dims["y"].group == "temporal"
+    assert spec.dims["z"].group is None
+    assert spec.dims["w"].group is None

--- a/test/test_dim_groups.py
+++ b/test/test_dim_groups.py
@@ -1,0 +1,128 @@
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from xattree import _get_xatspec, array, dim, xattree
+
+
+def test_dim_group_parameter():
+    """Test that the group parameter works correctly for dim fields."""
+
+    @xattree
+    class TestClass:
+        x: int = dim(group="space", default=3)
+        y: int = dim(group="time", default=4)
+        z: int = dim(group=None, default=5)  # Explicitly None
+        w: int = dim(default=6)  # No group parameter
+
+    # Test that the class can be instantiated
+    instance = TestClass()
+
+    # Test that the values are correct
+    assert instance.x == 3
+    assert instance.y == 4
+    assert instance.z == 5
+    assert instance.w == 6
+
+    # Test that the specifications have the correct group attributes
+    spec = _get_xatspec(TestClass)
+
+    assert spec.dims["x"].group == "space"
+    assert spec.dims["y"].group == "time"
+    assert spec.dims["z"].group is None
+    assert spec.dims["w"].group is None
+
+
+def test_array_dim_groups():
+    """Test that array fields have correct dim_groups computed."""
+
+    @xattree
+    class TestClass:
+        time: int = dim(group="time", default=3)
+        lat: int = dim(group="space", default=4)
+        lon: int = dim(group="space", default=5)
+        depth: int = dim(default=6)  # No group
+
+        # Array with grouped dimensions
+        temp: NDArray[np.float64] = array(dims=("time", "lat", "lon", "depth"), default=0.0)
+
+        # Array with only one group
+        spatial_data: NDArray[np.float64] = array(dims=("lat", "lon"), default=1.0)
+
+        # Array with ungrouped dimensions
+        simple_data: NDArray[np.float64] = array(dims=("depth",), default=2.0)
+
+    spec = _get_xatspec(TestClass)
+
+    # Check temp array dim_groups
+    temp_array = spec.arrays["temp"]
+    assert temp_array.dims == ("time", "lat", "lon", "depth")
+    assert temp_array.dim_groups == ("time", "space", "space", None)
+
+    # Check spatial_data array dim_groups
+    spatial_array = spec.arrays["spatial_data"]
+    assert spatial_array.dims == ("lat", "lon")
+    assert spatial_array.dim_groups == ("space", "space")
+
+    # Check simple_data array dim_groups
+    simple_array = spec.arrays["simple_data"]
+    assert simple_array.dims == ("depth",)
+    assert simple_array.dim_groups == (None,)
+
+
+def test_array_dim_groups_validation():
+    """Test that non-disjoint group ordering in array dims raises an error."""
+
+    with pytest.raises(ValueError, match="not disjointly ordered by group"):
+
+        @xattree
+        class InvalidClass:
+            time: int = dim(group="time", default=3)
+            lat: int = dim(group="space", default=4)
+            lon: int = dim(group="space", default=5)
+
+            # This should fail because we have space, then time, then space again
+            # which makes the space group non-contiguous
+            a: NDArray[np.float64] = array(dims=("lat", "time", "lon"), default=0.0)
+
+
+def test_array_dim_groups_class_order_irrelevant():
+    """Test that class definition order doesn't matter, only array dims order."""
+
+    @xattree
+    class TestClass:
+        # Define dimensions in mixed order in the class
+        lat: int = dim(group="space", default=4)
+        time: int = dim(group="time", default=2)
+        lon: int = dim(group="space", default=5)
+
+        # Array dims are properly ordered by group even though class defs aren't
+        a: NDArray[np.float64] = array(dims=("time", "lat", "lon"), default=0.0)
+
+    spec = _get_xatspec(TestClass)
+    data_array = spec.arrays["a"]
+
+    # Should work fine because the array dims are properly grouped
+    assert data_array.dim_groups == ("time", "space", "space")
+
+
+def test_array_dim_groups_multiple_groups():
+    """Test arrays with multiple groups in correct order."""
+
+    @xattree
+    class TestClass:
+        time: int = dim(group="time", default=2)
+        lat: int = dim(group="space", default=4)
+        lon: int = dim(group="space", default=5)
+        depth1: int = dim(group="vertical", default=6)
+        depth2: int = dim(group="vertical", default=7)
+        species: int = dim(default=8)  # No group
+
+        a: NDArray[np.float64] = array(
+            dims=("time", "lat", "lon", "depth1", "depth2", "species"), default=0.0
+        )
+
+    spec = _get_xatspec(TestClass)
+    data_array = spec.arrays["a"]
+
+    assert data_array.dim_groups == ("time", "space", "space", "vertical", "vertical", None)

--- a/xattree/__init__.py
+++ b/xattree/__init__.py
@@ -208,6 +208,7 @@ _NAME = "name"
 _DATA = "data"
 _HOST = "host"
 _KIND = "kind"
+_GROUP = "group"
 _COORD = "coord"
 _DIMS = "dims"
 _SCOPE = "scope"
@@ -359,6 +360,7 @@ class Array(Xattribute):
 
     dims: Optional[tuple[str, ...]] = None
     dtype: Optional["type"] = None
+    dim_groups: Optional[tuple[Optional[str], ...]] = None
 
 
 @define
@@ -377,6 +379,7 @@ class Dim(Xattribute):
     path: Optional[str] = None
     scope: Optional[str] = None
     coord: Optional[bool | str] = True
+    group: Optional[str] = None
 
 
 ChildKind = Literal["only", "list", "dict"]
@@ -468,6 +471,7 @@ def _get_xatspec(cls: type) -> XatSpec:
                         metadata=metadata,
                         coord=xatmeta.get(_COORD, False),
                         scope=xatmeta.get(_SCOPE, None),
+                        group=xatmeta.get(_GROUP, None),
                         type=type_,
                     )
                 case "coord":
@@ -554,6 +558,15 @@ def _get_xatspec(cls: type) -> XatSpec:
                             optional=is_optional,
                             metadata=metadata,
                         )
+
+        # Post-process arrays to compute dim_groups
+        for array_name, array_spec in arrays.items():
+            if array_spec.dims:
+                try:
+                    dim_groups = _compute_dim_groups(array_spec.dims, dims)
+                    arrays[array_name] = evolve(array_spec, dim_groups=dim_groups)
+                except ValueError as e:
+                    raise ValueError(f"Array '{array_name}': {e}") from e
 
         return XatSpec(dims=dims, attrs=attributes, arrays=arrays, coords=coords, children=children)
 
@@ -1041,6 +1054,7 @@ def field(
 def dim(
     scope=None,
     coord: bool | str = True,
+    group: Optional[str] = None,
     default=NOTHING,
     repr=True,
     eq=True,
@@ -1053,6 +1067,7 @@ def dim(
         _KIND: "dim",
         _COORD: coord,
         _SCOPE: scope,
+        _GROUP: group,
     }
     return attrs_field(
         default=default,
@@ -1470,3 +1485,56 @@ def xattree(
         return wrap
 
     return wrap(maybe_cls)
+
+
+def _compute_dim_groups(
+    array_dims: tuple[str, ...], dims_spec: dict[str, Dim]
+) -> tuple[Optional[str], ...]:
+    """
+    Compute the group for each dimension in an array field.
+
+    Parameters
+    ----------
+    array_dims : tuple[str, ...]
+        The dimension names for the array field
+    dims_spec : dict[str, Dim]
+        The dimension specifications for the class
+
+    Returns
+    -------
+    tuple[Optional[str], ...]
+        The group for each dimension, in the same order as array_dims
+
+    Raises
+    ------
+    ValueError
+        If dimensions are not disjointly ordered by group
+    """
+    if not array_dims:
+        return tuple()
+
+    # Get groups for each dim
+    dim_groups = []
+    for dim_name in array_dims:
+        if dim_name in dims_spec:
+            dim_groups.append(dims_spec[dim_name].group)
+        else:
+            # Dimension not found in current class, assume no group
+            dim_groups.append(None)
+
+    # Validate that dims are disjointly ordered by group
+    # This means all dims with the same group must be contiguous
+    seen_groups = []
+    current_group = None
+
+    for group in dim_groups:
+        if group != current_group:
+            if group in seen_groups:
+                raise ValueError(
+                    f"Array dimensions are not disjointly ordered by group. "
+                    f"Group '{group}' appears in non-contiguous positions: {dim_groups}"
+                )
+            seen_groups.append(group)  # type: ignore
+            current_group = group
+
+    return tuple(dim_groups)


### PR DESCRIPTION
add the concept of a dimension group. e.g. lat and lon might be in a "spatial" group. this supports array conversion from sparse dict representations, where keys are coords.