### PR TITLE
sparse threshold for array conversion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,3 +102,7 @@ plugins = [
 ]
 ignore_missing_imports = true
 warn_unreachable = true
+
+[tool.codespell]
+skip = "**.ipynb"
+ignore-words-list = ["coo"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = ["xattree[lint,test]"]
+sparse = ["sparse>=0.15.5,<1", "llvmlite>=0.44.0"]
 lint = ["ruff", "mypy"]
 test = [
     "xattree[lint]",

--- a/test/test_array_converters.py
+++ b/test/test_array_converters.py
@@ -662,3 +662,347 @@ def test_dict_converter_empty_dict():
 
     foo = Foo(t=2, x=2, temp={})
     assert foo.temp is None
+
+
+def test_sparse_dict_converter_large_array():
+    """Test dict converter creates sparse array for large arrays."""
+    from xattree import _SPARSE_AVAILABLE, set_sparse_config
+
+    if not _SPARSE_AVAILABLE:
+        pytest.skip("sparse package not available")
+
+    import sparse
+
+    # Set a low threshold to trigger sparse creation
+    set_sparse_config(threshold=10)
+
+    @xattree
+    class Foo:
+        t: int = dim()
+        x: int = dim()
+        y: int = dim()
+        temp: NDArray[np.float64] = array(
+            dims=("t", "x", "y"),
+            converter=dict_to_array_converter,
+        )
+
+    # Create 5x5x5 = 125 element array (exceeds threshold of 10)
+    # Only provide sparse data
+    d = {0: {0: {0: 1.0, 2: 2.0}}, 2: {1: {1: 3.0}}}
+    foo = Foo(t=5, x=5, y=5, temp=d)
+
+    assert foo.temp.shape == (5, 5, 5)
+    assert isinstance(foo.temp.data, sparse.COO)
+    assert foo.temp.data.nnz == 3  #
+    assert foo.temp[0, 0, 0] == 1.0
+    assert foo.temp[0, 0, 2] == 2.0
+    assert foo.temp[2, 1, 1] == 3.0
+    assert np.isnan(foo.temp[0, 0, 1])
+    assert np.isnan(foo.temp[1, 1, 1])
+
+    # Reset threshold
+    set_sparse_config(threshold=100_000)
+
+
+def test_sparse_table_converter_large_array():
+    """Test table converter creates sparse array for large arrays."""
+    from xattree import _SPARSE_AVAILABLE, set_sparse_config
+
+    if not _SPARSE_AVAILABLE:
+        pytest.skip("sparse package not available")
+
+    import sparse
+
+    # Set a low threshold to trigger sparse creation
+    set_sparse_config(threshold=10)
+
+    @xattree
+    class Foo:
+        t: int = dim()
+        x: int = dim()
+        y: int = dim()
+        temp: NDArray[np.float64] = array(
+            dims=("t", "x", "y"),
+            converter=table_to_array_converter,
+        )
+
+    # Create DataFrame with sparse data for 5x5x5 array
+    df = pd.DataFrame({"t": [0, 0, 2], "x": [0, 0, 1], "y": [0, 2, 1], "temp": [1.0, 2.0, 3.0]})
+
+    foo = Foo(t=5, x=5, y=5, temp=df)
+
+    assert foo.temp.shape == (5, 5, 5)
+    assert isinstance(foo.temp.data, sparse.COO)
+    assert foo.temp.data.nnz == 3
+    assert foo.temp[0, 0, 0] == 1.0
+    assert foo.temp[0, 0, 2] == 2.0
+    assert foo.temp[2, 1, 1] == 3.0
+
+    # Reset threshold
+    set_sparse_config(threshold=100_000)
+
+
+def test_sparse_dict_converter_grouped_dims():
+    """Test sparse dict converter with grouped dimensions."""
+    from xattree import _SPARSE_AVAILABLE, set_sparse_config
+
+    if not _SPARSE_AVAILABLE:
+        pytest.skip("sparse package not available")
+
+    set_sparse_config(threshold=10)
+
+    @xattree
+    class Foo:
+        t: int = dim(group="time")
+        x: int = dim(group="space")
+        y: int = dim(group="space")
+        temp: NDArray[np.float64] = array(
+            dims=("t", "x", "y"),
+            converter=dict_to_array_converter,
+        )
+
+    # Grouped structure: time -> (space coords) -> value
+    d = {0: {(0, 0): 1.0, (1, 2): 2.0}, 3: {(2, 1): 3.0}}
+    foo = Foo(t=5, x=5, y=5, temp=d)
+
+    # Should create sparse array
+    assert foo.temp.shape == (5, 5, 5)
+    assert foo.temp.data.nnz == 3
+
+    # Verify grouped coordinate structure is handled correctly
+    assert foo.temp[0, 0, 0] == 1.0
+    assert foo.temp[0, 1, 2] == 2.0
+    assert foo.temp[3, 2, 1] == 3.0
+
+    set_sparse_config(threshold=100_000)
+
+
+def test_sparse_array_fill_values():
+    """Test sparse arrays use correct fill values."""
+    from xattree import _SPARSE_AVAILABLE, set_sparse_config
+
+    if not _SPARSE_AVAILABLE:
+        pytest.skip("sparse package not available")
+
+    set_sparse_config(threshold=1)
+
+    # Test with custom fill value
+    @xattree
+    class IntFoo:
+        t: int = dim()
+        x: int = dim()
+        count: NDArray[np.int32] = array(
+            dims=("t", "x"),
+            converter=dict_to_array_converter,
+            default=-999,  # Custom fill value
+        )
+
+    d = {0: {0: 42}}
+    foo = IntFoo(t=3, x=3, count=d)
+
+    assert foo.count[0, 0] == 42
+    assert foo.count[1, 1] == -999  # Fill value for missing element
+
+    # Test with dtype-inferred fill value
+    @xattree
+    class FloatFoo:
+        t: int = dim()
+        x: int = dim()
+        temp: NDArray[np.float64] = array(
+            dims=("t", "x"),
+            converter=dict_to_array_converter,
+        )
+
+    d = {0: {0: 3.14}}
+    foo_f = FloatFoo(t=3, x=3, temp=d)
+
+    assert foo_f.temp[0, 0] == 3.14
+    assert np.isnan(foo_f.temp[1, 1])
+
+    set_sparse_config(threshold=100_000)
+
+
+def test_sparse_empty_data():
+    """Test sparse array creation with empty data."""
+    from xattree import _SPARSE_AVAILABLE, set_sparse_config
+
+    if not _SPARSE_AVAILABLE:
+        pytest.skip("sparse package not available")
+
+    set_sparse_config(threshold=1)
+
+    @xattree
+    class Foo:
+        t: int = dim()
+        x: int = dim()
+        temp: NDArray[np.float64] = array(
+            dims=("t", "x"),
+            converter=dict_to_array_converter,
+        )
+
+    # Empty dict should create empty sparse array
+    foo = Foo(t=5, x=5, temp={})
+
+    assert foo.temp.shape == (5, 5)
+    assert foo.temp.data.nnz == 0  # No non-zero elements
+    assert np.isnan(foo.temp[0, 0])  # All elements should be fill value
+
+    set_sparse_config(threshold=100_000)
+
+
+def test_set_sparse_config_api():
+    """Test the sparse configuration API."""
+    from xattree import _SPARSE_AVAILABLE, _SPARSE_CONFIG, set_sparse_config
+
+    if not _SPARSE_AVAILABLE:
+        # Test error when trying to enable sparse without package
+        with pytest.raises(ImportError, match="Cannot enable sparse arrays"):
+            set_sparse_config(enabled=True)
+        return
+
+    # Save original config
+    orig_threshold = _SPARSE_CONFIG.threshold
+    orig_enabled = _SPARSE_CONFIG.enabled
+
+    try:
+        # Test setting threshold
+        set_sparse_config(threshold=50_000)
+        assert _SPARSE_CONFIG.threshold == 50_000
+
+        # Test disabling
+        set_sparse_config(enabled=False)
+        assert not _SPARSE_CONFIG.enabled
+
+        # Test re-enabling
+        set_sparse_config(enabled=True)
+        assert _SPARSE_CONFIG.enabled
+
+        # Test setting both
+        set_sparse_config(threshold=75_000, enabled=False)
+        assert _SPARSE_CONFIG.threshold == 75_000
+        assert not _SPARSE_CONFIG.enabled
+
+    finally:
+        # Restore original config
+        set_sparse_config(threshold=orig_threshold, enabled=orig_enabled)
+
+
+def test_sparse_vs_dense_behavior_consistency():
+    """Test that sparse and dense arrays behave consistently for the same data."""
+    from xattree import _SPARSE_AVAILABLE, set_sparse_config
+
+    if not _SPARSE_AVAILABLE:
+        pytest.skip("sparse package not available")
+
+    import sparse
+
+    # Test data
+    test_data = {0: {0: 1.0, 2: 2.0}, 1: {1: 3.0}, 3: {0: 4.0, 2: 5.0}}
+
+    # Create dense version
+    set_sparse_config(threshold=1_000_000)  # High threshold = dense
+
+    @xattree
+    class DenseFoo:
+        t: int = dim()
+        x: int = dim()
+        temp: NDArray[np.float64] = array(
+            dims=("t", "x"),
+            converter=dict_to_array_converter,
+        )
+
+    dense_foo = DenseFoo(t=5, x=5, temp=test_data)
+
+    # Create sparse version
+    set_sparse_config(threshold=1)  # Low threshold = sparse
+
+    @xattree
+    class SparseFoo:
+        t: int = dim()
+        x: int = dim()
+        temp: NDArray[np.float64] = array(
+            dims=("t", "x"),
+            converter=dict_to_array_converter,
+        )
+
+    sparse_foo = SparseFoo(t=5, x=5, temp=test_data)
+
+    # Verify dense is numpy array, sparse is COO
+    assert isinstance(dense_foo.temp.data, np.ndarray)
+    assert isinstance(sparse_foo.temp.data, sparse.COO)
+
+    # Verify they have the same values at all positions
+    for t in range(5):
+        for x in range(5):
+            dense_val = dense_foo.temp[t, x]
+            sparse_val = sparse_foo.temp[t, x]
+
+            # Both should be NaN or both should be equal
+            if np.isnan(dense_val):
+                assert np.isnan(sparse_val)
+            else:
+                assert dense_val == sparse_val
+
+    # Reset threshold
+    set_sparse_config(threshold=100_000)
+
+
+def test_sparse_config_context_manager():
+    """Test that sparse_config context manager temporarily overrides threshold."""
+    import numpy as np
+
+    from xattree import (
+        _SPARSE_AVAILABLE,
+        _SPARSE_CONFIG,
+        array,
+        dict_to_array_converter,
+        dim,
+        sparse_config,
+        xattree,
+    )
+
+    if not _SPARSE_AVAILABLE:
+        import pytest
+
+        pytest.skip("sparse package not available")
+
+    import sparse
+
+    # Save original config
+    orig_threshold = _SPARSE_CONFIG.threshold
+    orig_enabled = _SPARSE_CONFIG.enabled
+
+    @xattree
+    class Foo:
+        t: int = dim()
+        x: int = dim()
+        temp: NDArray[np.float64] = array(
+            dims=("t", "x"),
+            converter=dict_to_array_converter,
+        )
+
+    # Data for 5x5 array (25 elements)
+    d = {0: {0: 1.0}, 4: {4: 2.0}}
+
+    try:
+        # Set a high threshold so dense by default
+        _SPARSE_CONFIG.threshold = 100_000
+        _SPARSE_CONFIG.enabled = True
+
+        foo = Foo(t=5, x=5, temp=d)
+        assert isinstance(foo.temp.data, np.ndarray)
+
+        # Now use context manager to lower threshold so sparse is triggered
+        with sparse_config(threshold=1):
+            foo2 = Foo(t=5, x=5, temp=d)
+            assert isinstance(foo2.temp.data, sparse.COO)
+            assert foo2.temp.data.nnz == 2
+
+        # After context, should revert to dense
+        foo3 = Foo(t=5, x=5, temp=d)
+        assert isinstance(foo3.temp.data, np.ndarray)
+
+    finally:
+        # Restore original config
+        _SPARSE_CONFIG.threshold = orig_threshold
+        _SPARSE_CONFIG.enabled = orig_enabled

--- a/xattree/__init__.py
+++ b/xattree/__init__.py
@@ -6,6 +6,7 @@ import builtins
 import types
 from collections import ChainMap
 from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping, MutableSequence
+from contextlib import contextmanager
 from datetime import datetime
 from inspect import isclass
 from itertools import chain
@@ -42,6 +43,92 @@ from numpy.typing import ArrayLike, NDArray
 from xarray.core.indexes import PandasIndex
 
 _PKG_NAME = "xattree"
+
+# Sparse array support
+try:
+    import sparse
+
+    _SPARSE_AVAILABLE = True
+except ImportError:
+    _SPARSE_AVAILABLE = False
+    sparse = None  # type: ignore
+
+
+@define
+class SparseConfig:
+    """Global configuration for sparse array creation."""
+
+    threshold: int = 100_000
+    enabled: bool = _SPARSE_AVAILABLE
+
+    def set(self, threshold: Optional[int] = None, enabled: Optional[bool] = None):
+        """Set sparse array threshold and/or enable/disable."""
+        if threshold is not None:
+            self.threshold = threshold
+        if enabled is not None:
+            if enabled and not _SPARSE_AVAILABLE:
+                raise ImportError(
+                    "Cannot enable sparse array conversion: 'sparse' package not available"
+                )
+            self.enabled = enabled
+
+
+_SPARSE_CONFIG = SparseConfig()
+
+
+def set_sparse_config(threshold: Optional[int] = None, enabled: Optional[bool] = None):
+    """
+    Set global sparse array configuration.
+
+    Parameters
+    ----------
+    threshold : int, optional
+        Minimum number of elements before considering sparse conversion.
+    enabled : bool, optional
+        Enable or disable sparse array creation globally.
+    """
+    _SPARSE_CONFIG.set(threshold=threshold, enabled=enabled)
+
+
+@contextmanager
+def sparse_config(threshold: Optional[int] = None, enabled: Optional[bool] = None):
+    """
+    Context manager to temporarily override sparse array configuration.
+
+    Example
+    -------
+    >>> with sparse_config_context(threshold=50000):
+    ...     # code using temporary config
+    ...     pass
+    """
+    old = attrs_asdict(_SPARSE_CONFIG)
+    _SPARSE_CONFIG.set(threshold=threshold, enabled=enabled)
+    try:
+        yield
+    finally:
+        _SPARSE_CONFIG.set(**old)
+
+
+def _should_be_sparse(size: int) -> bool:
+    """
+    Determine if a sparse array should be created based on size.
+
+    Parameters
+    ----------
+    total_elements : int
+        Total number of elements the array would have
+    field_sparse_threshold : int, optional
+        Field-specific threshold override
+
+    Returns
+    -------
+    bool
+        True if a sparse array should be created
+    """
+    if not _SPARSE_CONFIG.enabled or sparse is None:
+        return False
+
+    return size >= _SPARSE_CONFIG.threshold
 
 
 class DataTreeList(MutableSequence):
@@ -1693,6 +1780,9 @@ def dict_to_array(value: Mapping | ArrayLike, self: Any, field: Array) -> Scalar
     - `default=None`: The entire field becomes None (no array created)
     - `default=NOTHING`: An array filled with appropriate fill values is created
 
+    If the sparse package is available and the array size exceeds the sparse
+    threshold, a sparse.COO array is returned instead of a dense numpy array.
+
     Parameters
     ----------
     value : dict or array-like
@@ -1709,8 +1799,8 @@ def dict_to_array(value: Mapping | ArrayLike, self: Any, field: Array) -> Scalar
 
     Returns
     -------
-    ndarray or None
-        Dense array with appropriate fill values for missing values.
+    ndarray or sparse.COO or None
+        Dense or sparse array with appropriate fill values for missing values.
         Returns None for empty dicts when field default is None.
 
     Examples
@@ -1743,13 +1833,13 @@ def dict_to_array(value: Mapping | ArrayLike, self: Any, field: Array) -> Scalar
 
     >>> # Field becomes None
     >>> temp: NDArray[np.float64] | None = array(
-    ...     dims=("t", "x"), converter=sparse_dict_converter, default=None
+    ...     dims=("t", "x"), converter=dict_to_array_converter, default=None
     ... )
     >>> obj = MyClass(t=2, x=2, temp={})  # temp will be None
 
     >>> # Field becomes NaN-filled array
     >>> temp: NDArray[np.float64] | None = array(
-    ...     dims=("t", "x"), converter=sparse_dict_converter, default=NOTHING
+    ...     dims=("t", "x"), converter=dict_to_array_converter, default=NOTHING
     ... )
     >>> obj = MyClass(t=2, x=2, temp={})  # temp will be 2x2 array of NaN
     """
@@ -1780,6 +1870,10 @@ def dict_to_array(value: Mapping | ArrayLike, self: Any, field: Array) -> Scalar
     if any(unresolved):
         raise ValueError(f"Couldn't resolve array field {field.name}'s dims: {unresolved}")
 
+    # Check if we should create a sparse array
+    total_elements = np.prod(shape)
+    create_sparse = _should_be_sparse(total_elements)
+
     # group dims, maintaining order
     grouped_dims = []  # type: ignore
     current_group, current_dims = None, []  # type: ignore
@@ -1809,55 +1903,100 @@ def dict_to_array(value: Mapping | ArrayLike, self: Any, field: Array) -> Scalar
         else np.nan
     )
 
-    # choose dtype strategy to avoid truncation
-    if fill_value is None or (
-        field.dtype is np.str_ or "str" in field.dtype.__name__.lower()  # type: ignore
-    ):
-        result = np.full(shape, fill_value, dtype=object)
-    elif field.dtype is not None:
-        try:
-            result = np.full(shape, fill_value, dtype=field.dtype)
-        except (ValueError, TypeError):
-            result = np.full(shape, fill_value, dtype=object)
+    if create_sparse:
+        # Create sparse array directly
+        coords_list = []
+        values_list = []
+
+        def _collect_sparse_data(d, level=0, indices=None):
+            if indices is None:
+                indices = []
+            if level >= len(grouped_dims):
+                coords_list.append(indices)
+                values_list.append(d)
+                return
+
+            if not isinstance(d, Mapping):
+                if len(indices) == len(field.dims):
+                    coords_list.append(indices)
+                    values_list.append(d)
+                    return
+                else:
+                    raise ValueError(f"Expected dict at level {level}, got {type(d).__name__}: {d}")
+
+            _, group_dims = grouped_dims[level]
+            for key, subd in d.items():
+                if len(group_dims) == 1:
+                    coords = [key]
+                else:
+                    if not isinstance(key, tuple) or len(key) != len(group_dims):
+                        raise ValueError(
+                            f"Expected tuple of {len(group_dims)} coords {group_dims}, got {key}"
+                        )
+                    coords = [coord for coord in key]
+                _collect_sparse_data(subd, level + 1, indices + coords)
+
+        _collect_sparse_data(value)
+
+        if coords_list:
+            # Convert coordinates to the format expected by sparse.COO
+            coords_array = np.array(coords_list).T  # Transpose to get (ndim, nnz) shape
+            return sparse.COO(coords_array, values_list, shape=shape, fill_value=fill_value)  # type: ignore
+        else:
+            # No data, return empty sparse array
+            return sparse.COO(np.empty((len(shape), 0)), [], shape=shape, fill_value=fill_value)  # type: ignore
+
     else:
-        try:
-            result = np.full(shape, fill_value)
-        except (ValueError, TypeError):
+        # Create dense array as before
+        # choose dtype strategy to avoid truncation
+        if fill_value is None or (
+            field.dtype is np.str_ or "str" in field.dtype.__name__.lower()  # type: ignore
+        ):
             result = np.full(shape, fill_value, dtype=object)
+        elif field.dtype is not None:
+            try:
+                result = np.full(shape, fill_value, dtype=field.dtype)
+            except (ValueError, TypeError):
+                result = np.full(shape, fill_value, dtype=object)
+        else:
+            try:
+                result = np.full(shape, fill_value)
+            except (ValueError, TypeError):
+                result = np.full(shape, fill_value, dtype=object)
 
-    # recursively populate the array
-    def _populate(d, level=0, indices=None):
-        if indices is None:
-            indices = []
-        if level >= len(grouped_dims):
-            result[tuple(indices)] = d
-            return
-
-        # if d is not a mapping, we've reached a leaf value early
-        if not isinstance(d, Mapping):
-            # this might be valid if we have fewer nesting levels than expected
-            # in that case, we should assign the value at the current position
-            if len(indices) == len(field.dims):
+        # recursively populate the array
+        def _populate(d, level=0, indices=None):
+            if indices is None:
+                indices = []
+            if level >= len(grouped_dims):
                 result[tuple(indices)] = d
                 return
-            else:
-                raise ValueError(f"Expected dict at level {level}, got {type(d).__name__}: {d}")
 
-        _, group_dims = grouped_dims[level]
-        for key, subd in d.items():
-            # single dim: key is coordinate, multiple dims: key must be tuple of coordinates
-            if len(group_dims) == 1:
-                coords = [key]
-            else:
-                if not isinstance(key, tuple) or len(key) != len(group_dims):
-                    raise ValueError(
-                        f"Expected tuple of {len(group_dims)} coords {group_dims}, got {key}"
-                    )
-                coords = [coord for coord in key]
-            _populate(subd, level + 1, indices + coords)
+            # if d is not a mapping, we've reached a leaf value early
+            if not isinstance(d, Mapping):
+                # this might be valid if we have fewer nesting levels than expected
+                # in that case, we should assign the value at the current position
+                if len(indices) == len(field.dims):
+                    result[tuple(indices)] = d
+                    return
+                else:
+                    raise ValueError(f"Expected dict at level {level}, got {type(d).__name__}: {d}")
 
-    _populate(value)
-    return result
+            _, group_dims = grouped_dims[level]
+            for key, subd in d.items():
+                # single dim: key is coordinate, multiple dims: key must be tuple of coordinates
+                if len(group_dims) == 1:
+                    coords = [key]
+                else:
+                    if not isinstance(key, tuple) or len(key) != len(group_dims):
+                        raise ValueError(
+                            f"Expected tuple of {len(group_dims)} coords {group_dims}, got {key}"
+                        )
+                    coords = [coord for coord in key]
+                _populate(subd, level + 1, indices + coords)
+
+        _populate(value)
+        return result
 
 
 dict_to_array_converter = Converter(dict_to_array, takes_self=True, takes_field=True)  # type: ignore
@@ -1876,6 +2015,9 @@ def table_to_array(value: ArrayLike, self: Any, field: Array) -> Scalar | NDArra
     For empty tables with optional array fields:
     - `default=None`: The entire field becomes None (no array created)
     - `default=NOTHING`: An array filled with appropriate fill values is created
+
+    If the sparse package is available and the array size exceeds the sparse
+    threshold, a sparse.COO array is returned instead of a dense numpy array.
 
     Parameters
     ----------
@@ -1907,6 +2049,7 @@ def table_to_array(value: ArrayLike, self: Any, field: Array) -> Scalar | NDArra
     ... })
 
     Multiple value columns create record objects:
+
     >>> df = pd.DataFrame({
     ...     't': [10, 20],
     ...     'x': [40.0, 40.0],
@@ -1997,8 +2140,11 @@ def table_to_array(value: ArrayLike, self: Any, field: Array) -> Scalar | NDArra
     if any(unresolved):
         raise ValueError(f"Couldn't resolve array field {field.name}'s dims: {unresolved}")
 
+    # Check if we should create a sparse array
+    total_elements = np.prod(shape)
+    create_sparse = _should_be_sparse(total_elements)
+
     # Determine fill value and result dtype
-    result: np.ndarray
     if len(value_columns) == 1:
         # Single value column
         fill_value = (
@@ -2008,85 +2154,146 @@ def table_to_array(value: ArrayLike, self: Any, field: Array) -> Scalar | NDArra
             if field.dtype is not None
             else np.nan
         )
-
-        if field.dtype is not None:
-            try:
-                result = np.full(shape, fill_value, dtype=field.dtype)
-            except (ValueError, TypeError):
-                result = np.full(shape, fill_value, dtype=object)
-        else:
-            try:
-                result = np.full(shape, fill_value)
-            except (ValueError, TypeError):
-                result = np.full(shape, fill_value, dtype=object)
     else:
         # Multiple value columns - create record objects
-        from attrs import define
-        from attrs import field as attrs_field
+        fill_value = None
 
-        # Create a record class dynamically
-        record_fields = {}
-        for col in value_columns:
-            record_fields[col] = attrs_field()
+    if create_sparse:
+        # Create sparse array directly from table data
+        coords_list = []
+        values_list = []
 
-        Record = define(type("Record", (), record_fields))
+        # Process each row
+        for row_idx in range(len(value)):  # type: ignore
+            # Get coordinate indices for this row - use coordinate values directly as indices
+            indices = []
+            skip_row = False
 
-        # Fill value is None for object arrays containing records
-        result = np.full(shape, None, dtype=object)
+            for dim_name in field.dims:
+                if dim_name in coord_columns:
+                    if is_recarray:
+                        coord_val = value[dim_name][row_idx]  # type: ignore
+                    else:
+                        coord_val = value.iloc[row_idx][dim_name]  # type: ignore
 
-    # Create coordinate lookup for fast indexing
-    coord_to_index = {}
-    for i, dim_name in enumerate(field.dims):
-        if dim_name in coord_columns:
-            # Get unique coordinates for this dimension
-            unique_coords = np.unique(get_column(dim_name))
-            coord_to_index[dim_name] = {coord: idx for idx, coord in enumerate(unique_coords)}
-
-    # Populate the array
-    for row_idx in range(len(value)):  # type: ignore
-        # Get coordinate indices for this row
-        indices = []
-        skip_row = False
-
-        for dim_name in field.dims:
-            if dim_name in coord_columns:
-                if is_recarray:
-                    coord_val = value[dim_name][row_idx]  # type: ignore
+                    # Use coordinate value directly as array index
+                    indices.append(int(coord_val))  # type: ignore
                 else:
-                    coord_val = value.iloc[row_idx][dim_name]  # type: ignore
-
-                if dim_name in coord_to_index and coord_val in coord_to_index[dim_name]:
-                    indices.append(coord_to_index[dim_name][coord_val])
-                else:
-                    # Coordinate not found, skip this row
+                    # Dimension not in coordinate columns, can't place this row
                     skip_row = True
                     break
-            else:
-                # Dimension not in coordinate columns, can't place this row
-                skip_row = True
-                break
 
-        if skip_row or len(indices) != len(field.dims):
-            continue
+            if skip_row or len(indices) != len(field.dims):
+                continue
 
-        # Extract value(s) for this row
-        if len(value_columns) == 1:
-            if is_recarray:
-                val = value[value_columns[0]][row_idx]  # type: ignore
-            else:
-                val = value.iloc[row_idx][value_columns[0]]  # type: ignore
-            result[tuple(indices)] = val
-        else:
-            # Create record object
-            record_data = {}
-            for col in value_columns:
+            # Extract value(s) for this row
+            if len(value_columns) == 1:
                 if is_recarray:
-                    record_data[col] = value[col][row_idx]  # type: ignore
+                    val = value[value_columns[0]][row_idx]  # type: ignore
                 else:
-                    record_data[col] = value.iloc[row_idx][col]  # type: ignore
-            result[tuple(indices)] = Record(**record_data)
+                    val = value.iloc[row_idx][value_columns[0]]  # type: ignore
+                coords_list.append(indices)
+                values_list.append(val)
+            else:
+                # Create record object
+                from attrs import define
+                from attrs import field as attrs_field
 
-    return result
+                # Create a record class dynamically
+                record_fields = {}
+                for col in value_columns:
+                    record_fields[col] = attrs_field()
+
+                Record = define(type("Record", (), record_fields))
+
+                record_data = {}
+                for col in value_columns:
+                    if is_recarray:
+                        record_data[col] = value[col][row_idx]  # type: ignore
+                    else:
+                        record_data[col] = value.iloc[row_idx][col]  # type: ignore
+                coords_list.append(indices)
+                values_list.append(Record(**record_data))
+
+        if coords_list:
+            # Convert coordinates to the format expected by sparse.COO
+            coords_array = np.array(coords_list).T  # Transpose to get (ndim, nnz) shape
+            return sparse.COO(coords_array, values_list, shape=shape, fill_value=fill_value)  # type: ignore
+        else:
+            # No data, return empty sparse array
+            return sparse.COO(np.empty((len(shape), 0)), [], shape=shape, fill_value=fill_value)  # type: ignore
+
+    else:
+        # Create dense array as before
+        result: np.ndarray
+        if len(value_columns) == 1:
+            # Single value column
+            if field.dtype is not None:
+                try:
+                    result = np.full(shape, fill_value, dtype=field.dtype)
+                except (ValueError, TypeError):
+                    result = np.full(shape, fill_value, dtype=object)
+            else:
+                try:
+                    result = np.full(shape, fill_value)
+                except (ValueError, TypeError):
+                    result = np.full(shape, fill_value, dtype=object)
+        else:
+            # Multiple value columns - create record objects
+            from attrs import define
+            from attrs import field as attrs_field
+
+            # Create a record class dynamically
+            record_fields = {}
+            for col in value_columns:
+                record_fields[col] = attrs_field()
+
+            Record = define(type("Record", (), record_fields))
+
+            # Fill value is None for object arrays containing records
+            result = np.full(shape, None, dtype=object)
+
+        # Populate the array
+        for row_idx in range(len(value)):  # type: ignore
+            # Get coordinate indices for this row - use coordinate values directly as indices
+            indices = []
+            skip_row = False
+
+            for dim_name in field.dims:
+                if dim_name in coord_columns:
+                    if is_recarray:
+                        coord_val = value[dim_name][row_idx]  # type: ignore
+                    else:
+                        coord_val = value.iloc[row_idx][dim_name]  # type: ignore
+
+                    # Use coordinate value directly as array index
+                    indices.append(int(coord_val))  # type: ignore
+                else:
+                    # Dimension not in coordinate columns, can't place this row
+                    skip_row = True
+                    break
+
+            if skip_row or len(indices) != len(field.dims):
+                continue
+
+            # Extract value(s) for this row
+            if len(value_columns) == 1:
+                if is_recarray:
+                    val = value[value_columns[0]][row_idx]  # type: ignore
+                else:
+                    val = value.iloc[row_idx][value_columns[0]]  # type: ignore
+                result[tuple(indices)] = val
+            else:
+                # Create record object
+                record_data = {}
+                for col in value_columns:
+                    if is_recarray:
+                        record_data[col] = value[col][row_idx]  # type: ignore
+                    else:
+                        record_data[col] = value.iloc[row_idx][col]  # type: ignore
+                result[tuple(indices)] = Record(**record_data)
+
+        return result
 
 
 table_to_array_converter = Converter(table_to_array, takes_self=True, takes_field=True)  # type: ignore


### PR DESCRIPTION
add a `sparse` optional dependency group and a "sparse threshold" feature for array conversion. if `sparse` is available and an array is larger than the threshold, dict- and table-to-array conversion will return a `sparse.COO`.