### PR TITLE
rename array cls -> dtype, accept str or np.dtype

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "attrs",
     "cattrs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,4 +99,4 @@ warn_unreachable = true
 
 [tool.codespell]
 skip = "**.ipynb"
-ignore-words-list = ["coo"]
+ignore-words-list = ["coo", "thre"]

--- a/test/test_array.py
+++ b/test/test_array.py
@@ -146,19 +146,54 @@ def test_record_array_default():
     assert all(isinstance(r, Records.Record) for r in records.arr.to_numpy())
 
 
-def test_scalar_union_array():
+def test_fixed_size_string_array_with_default():
     @xattree
-    class Unions:
+    class Strings:
         n: int = dim(default=3)
-        arr: NDArray[np.object_] = array(np.int64 | np.float64, default=1, dims=("n",))
+        arr: NDArray[np.str_] = array(default="a", dims=("n",))
 
-    unions = Unions()
-    assert unions.arr.dtype is np.dtype(np.int64)
-    assert np.array_equal(unions.arr, np.ones(3, dtype=np.int64))
+    strings = Strings()
+    assert strings.arr.dtype == np.dtype((np.str_, 1))
+    assert np.array_equal(strings.arr, np.full(3, "a"))
 
-    # TODO: type checking that values are members of union?
-    # arr = np.array([True, True, False])
-    # assert pytest.raises(TypeError, Unions, arr=arr)
+
+def test_fixed_size_string_array_with_dtype_and_default():
+    @xattree
+    class Strings:
+        n: int = dim(default=3)
+        arr: NDArray[np.str_] = array("<U5", default="hello", dims=("n",))
+
+    strings = Strings()
+    assert strings.arr.dtype == np.dtype((np.str_, 5))
+    assert np.array_equal(strings.arr, np.full(3, "hello"))
+
+
+def test_fixed_size_string_array_with_dtype_and_no_default():
+    @xattree
+    class Strings:
+        n: int = dim(default=3)
+        arr: NDArray[np.str_] = array("<U4", dims=("n",))
+
+    strings = Strings()
+    assert strings.arr.dtype == np.dtype((np.str_, 4))
+    assert np.array_equal(strings.arr, np.full(3, ""))
+
+    strings.arr = np.array(["one", "two", "three"])
+    assert np.array_equal(strings.arr, np.array(["one", "two", "thre"]))  # truncated
+
+
+def test_variable_sized_string_array_with_no_default():
+    @xattree
+    class Strings:
+        n: int = dim(default=3)
+        arr: NDArray[np.str_] = array(np.dtypes.StringDType(), dims=("n",))
+
+    strings = Strings()
+    assert strings.arr.dtype == np.dtype(np.dtypes.StringDType())
+    assert np.array_equal(strings.arr, np.full(3, ""))
+
+    strings.arr = np.array(["one", "two", "three"])
+    assert np.array_equal(strings.arr, np.array(["one", "two", "three"]))  # not truncated
 
 
 def test_record_union_array():
@@ -173,33 +208,9 @@ def test_record_union_array():
     @xattree
     class Unions:
         n: int = dim(default=3)
-        arr: NDArray[np.object_] = array(RecordA | RecordB, default=Factory(RecordA), dims=("n",))
+        # if dtype is a union, it resolves to an object array
+        arr: NDArray = array(RecordA | RecordB, default=Factory(RecordA), dims=("n",))
 
     unions = Unions()
     assert unions.arr.dtype is np.dtype(np.object_)
     assert np.array_equal(unions.arr, np.full(3, RecordA()))
-
-
-def test_array_with_list_type_hint():
-    """
-    When a list type hint is used, the array should be
-    initialized as an array of the proper scalar type,
-    if possible, otherwise as an object array.
-    """
-
-    class Record:
-        pass
-
-    @xattree
-    class Foo:
-        n: int = dim(default=3)
-        list_int: list[int] = array(default=0, dims=("n",))
-        list_flt: list[float] = array(default=0.0, dims=("n",))
-        list_str: list[str] = array(default="a", dims=("n",))
-        list_obj: list[Record] = array(default=Factory(Record), dims=("n",))
-
-    foo = Foo()
-    assert foo.list_int.dtype is np.dtype(np.int64)
-    assert foo.list_flt.dtype is np.dtype(np.float64)
-    assert foo.list_str.dtype == np.dtype((np.str_, 1))
-    assert foo.list_obj.dtype is np.dtype(np.object_)

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -19,7 +19,7 @@ def array_from_dict(data):
 def test_array_converter():
     @xattree
     class TestClass:
-        a: NDArray[np.integer] = array(converter=array_from_dict)
+        a: NDArray[np.int_] = array(converter=array_from_dict)
 
     obj = TestClass(a={0: 1, 2: 3})
     expected = np.array([1, 0, 3])
@@ -33,7 +33,7 @@ def test_array_converter_takes_self():
 
     @xattree
     class TestClass:
-        a: NDArray[np.integer] = array(converter=attrs.Converter(convert, takes_self=True))
+        a: NDArray[np.int_] = array(converter=attrs.Converter(convert, takes_self=True))
 
     obj = TestClass(a=1)
     expected = np.array(2)
@@ -47,7 +47,7 @@ def test_array_converter_takes_field():
 
     @xattree
     class TestClass:
-        a: NDArray[np.integer] = array(converter=attrs.Converter(convert, takes_field=True))
+        a: NDArray[np.int_] = array(converter=attrs.Converter(convert, takes_field=True))
 
     obj = TestClass(a=1)
     expected = np.array(2)
@@ -62,7 +62,7 @@ def test_array_converter_takes_self_and_field():
 
     @xattree
     class TestClass:
-        a: NDArray[np.integer] = array(
+        a: NDArray[np.int_] = array(
             converter=attrs.Converter(convert, takes_self=True, takes_field=True)
         )
 

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -8,7 +8,8 @@ from xattree import Xattribute, array, xattree
 def array_from_dict(data):
     if isinstance(data, dict):
         max_index = max(data.keys())
-        arr = np.full(max_index + 1, np.nan)
+
+        arr = np.full(max_index + 1, 0)
         for k, v in data.items():
             arr[k] = v
         return arr
@@ -21,7 +22,7 @@ def test_array_converter():
         a: NDArray[np.integer] = array(converter=array_from_dict)
 
     obj = TestClass(a={0: 1, 2: 3})
-    expected = np.array([1.0, np.nan, 3.0])
+    expected = np.array([1, 0, 3])
     np.testing.assert_array_equal(obj.a, expected)
 
 

--- a/test/test_inheritance.py
+++ b/test/test_inheritance.py
@@ -13,7 +13,7 @@ def test_subclass():
     @xattree
     class Child(Base):
         n: int = dim(default=3)
-        a: NDArray[np.floating] = array(dims=("n",), default=1.0)
+        a: NDArray[np.float64] = array(dims=("n",), default=1.0)
 
     spec = get_xatspec(Child).flat
     assert len(spec) == 2
@@ -28,7 +28,7 @@ def test_subclass_inherits_fields():
     @xattree
     class Base:
         n: int = dim(default=3)
-        a: NDArray[np.floating] = array(dims=("n",), default=1.0)
+        a: NDArray[np.float64] = array(dims=("n",), default=1.0)
 
     @xattree
     class Child(Base):

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -70,11 +70,11 @@ def test_fields_extra():
     assert list(fields_dict(Foo, extra=True).values()) == fields_
 
 
-def test_xatspec():
+def test_get_xatspec():
     @xattree
     class Foo:
-        c: NDArray[np.integer] = coord()
-        a: NDArray[np.floating] = array()
+        c: NDArray[np.int_] = coord()
+        a: NDArray[np.float64] = array()
 
     xatspec = get_xatspec(Foo)
     assert "c" in xatspec.coords

--- a/test/test_validator.py
+++ b/test/test_validator.py
@@ -43,7 +43,7 @@ def test_scalar_fields_with_explicit_validators():
 
 @xattree
 class ArrayFoo:
-    arr: NDArray[np.integer] = array(
+    arr: NDArray[np.int_] = array(
         validator=[
             attrs.validators.instance_of(np.ndarray),
             attrs.validators.deep_iterable(

--- a/xattree/__init__.py
+++ b/xattree/__init__.py
@@ -214,7 +214,7 @@ _DIMS = "dims"
 _SCOPE = "scope"
 _SPEC = "spec"
 _STRICT = "strict"
-_TYPE = "type"
+_DTYPE = "dtype"
 _OPTIONAL = "optional"
 _CONVERTER = "converter"
 _CONVERTERS = "converters"
@@ -360,7 +360,7 @@ class Array(Xattribute):
     """Specifies an array field."""
 
     dims: Optional[tuple[str, ...]] = None
-    dtype: Optional["type"] = None
+    dtype: Optional[np.dtype] = None
 
 
 @define
@@ -409,16 +409,10 @@ class XatSpec:
         return ChainMap(self.dims, self.attrs, self.arrays, self.coords, self.children)  # type: ignore
 
 
-def _get_fill_value(dtype):
+def _get_fill_value(dtype: np.dtype):
     """Get a reasonable fill value for a given numpy dtype."""
 
-    # handle inexact cases
-    if dtype is np.floating:
-        return np.nan
-    elif dtype is np.integer:
-        return 0
-
-    if (dtype := np.dtype(dtype)) == np.object_:
+    if dtype == np.object_:
         return None
     elif np.issubdtype(dtype, np.floating):
         return np.nan
@@ -426,7 +420,7 @@ def _get_fill_value(dtype):
         return 0
     elif np.issubdtype(dtype, np.bool_):
         return False
-    elif np.issubdtype(dtype, np.str_):
+    elif np.issubdtype(dtype, np.str_) or isinstance(dtype, np.dtypes.StringDType):
         return ""
     elif np.issubdtype(dtype, np.bytes_):
         return b""
@@ -564,24 +558,31 @@ def _get_xatspec(cls: type) -> XatSpec:
                         type=type_,
                     )
                 case "array":
-                    dtype = None
+                    dtype = xatmeta.get(_DTYPE, None)
+                    if isinstance(dtype, type) or get_origin(dtype) in (Union, types.UnionType):
+                        dtype = np.dtype(np.object_)
                     if origin in (Union, types.UnionType):
+                        dtype = np.dtype(np.object_)
                         if args[-1] is types.NoneType:  # Optional
                             is_optional = True
                             type_ = args[0]
                             if get_origin(type_) is np.ndarray:
                                 origin = np.ndarray
-                                dtype = get_args(type_)[1].__args__[0]
+                                # dtype = dtype or get_args(type_)[1].__args__[0]
                             elif get_origin(type_) is list:
                                 origin = list
-                                dtype = get_args(type_)[0]
+                                # dtype = dtype or get_args(type_)[0]
                             else:
                                 origin = None
                         else:
                             raise TypeError(f"Field must have a concrete type: {field.name}")
                     elif origin is np.ndarray and args:
                         if len(args) >= 2 and hasattr(args[1], "__args__"):
-                            dtype = args[1].__args__[0]
+                            arg = args[1].__args__[0]
+                            if isinstance(arg, TypeVar):
+                                dtype = dtype or None
+                            else:
+                                dtype = dtype or arg
                     if not (isclass(origin) and issubclass(origin, (list, np.ndarray))):
                         raise TypeError(f"Array '{field.name}' type unsupported: {origin}")
 
@@ -596,7 +597,7 @@ def _get_xatspec(cls: type) -> XatSpec:
                         default=array_default,
                         optional=is_optional,
                         type=type_,
-                        dtype=dtype,
+                        dtype=np.dtype(dtype),
                         converter=field.converter,
                         metadata=metadata,
                     )
@@ -1022,6 +1023,9 @@ def _init_tree(
                 )
                 is not None
             ):
+                if xat.dtype is not None:
+                    array = array.astype(xat.dtype)
+
                 if xat.dims:
                     yield (xat.name, (xat.dims, array))
                 else:
@@ -1203,7 +1207,7 @@ def coord(
 
 
 def array(
-    cls=None,
+    dtype: np.dtype | str | type | None = None,
     dims=None,
     default=NOTHING,
     validator=None,
@@ -1217,13 +1221,18 @@ def array(
     dims = dims if isinstance(dims, Iterable) else tuple()
     if not any(dims) and isinstance(default, Scalar):
         raise CannotExpand("If no dims, no scalar defaults.")
-    if cls and default is NOTHING:
-        default = Factory(cls)
+    if dtype is not None and default is NOTHING:
+        if isinstance(dtype, (str, np.dtype)):
+            default = _get_fill_value(np.dtype(dtype))
+        elif isinstance(dtype, type):
+            default = Factory(dtype)
+        else:
+            raise ValueError(f"Invalid dtype '{dtype}', expected one of: np.dtype, str, type")
     metadata = metadata or {}
     metadata[_PKG_NAME] = {
         _KIND: "array",
         _DIMS: dims,
-        _TYPE: cls,
+        _DTYPE: dtype,
         _CONVERTER: converter,
         _VALIDATOR: validator,
     }
@@ -1462,7 +1471,7 @@ def xattree(
                     xatmeta.update(
                         {
                             _KIND: "child",
-                            _TYPE: type_,
+                            _DTYPE: type_,
                             _OPTIONAL: optional,
                             _MULTI: multi,
                         }
@@ -1538,6 +1547,8 @@ def xattree(
                     tree.attrs[xat.name] = value
                     setattr(self, where, tree)
                 case Array():
+                    if xat.dtype is not None:
+                        value = np.array(value).astype(xat.dtype)
                     tree[xat.name] = xr.DataArray(
                         value, dims=xat.dims, attrs={"metadata": xat.metadata}
                     )


### PR DESCRIPTION
Update the array field decorator signature `array(cls, ...)` -> `array(dtype, ...)` where `dtype` can now be a `str`, `np.dtype`, or `type` as before. if a `type` then we use `np.object_` dtype as before. Strings are passed to `np.dtype()`, this works for e.g. fixed-length string formats. Obviously dtype itself is allowed too. And if a dtype is provided, enforce it at init/modification time. Add tests.

Also remove some unnecessary behavior where list type hints were allowed for the array field decorator.